### PR TITLE
Remove the explicit size argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,17 @@ beacon> inlineExecute-Assembly --dotnetassembly /root/Desktop/simpleMain.exe --m
 beacon> inlineExecute-Assembly --dotnetassembly /root/Desktop/Seatbelt.exe --assemblyargs AntiVirus AppLocker --amsi --etw --appdomain forRealLegit --mailslot forRealLegit
 ```
 
+### Use Case
+
+> *Execute .NET assembly (Meterpreter Version)*
+
+### Syntax
+
+```
+meterpreter > load bofloader
+meterpreter > execute_bof path/to/inlineExecute-Assemblyx64.o --format-string ziiiiizzzb "totesLegit" 0 0 0 0 1 "totesLegit" "totesLegit" "" file:/root/Desktop/Seatbelt.exe
+```
+
 ## Caveats
 
 1.	While I have tried to make this as stable as possible, there are no guarantees things will never crash and beacons won’t die. We don’t have the added luxury of fork and run where if something goes wrong our beacon lives. This is the tradeoff with BOFs.  With that said, I can’t stress how important it is that you test your assemblies beforehand to make sure they will work properly with the tool. 

--- a/inlineExecuteAssembly/inlineExecute-Assembly.cna
+++ b/inlineExecuteAssembly/inlineExecute-Assembly.cna
@@ -340,7 +340,6 @@ alias inlineExecute-Assembly {
 
     #Reading assembly bytes and get the size in bytes
     $fileHandle = openf($_dotNetAssembly);
-    $assemblyLength = lof($_dotNetAssembly);
     $assemblyBytes = readb($fileHandle, -1);
     closef($fileHandle);
 
@@ -349,7 +348,7 @@ alias inlineExecute-Assembly {
   #-------------------------------------- Package and ship it --------------------------------------#
 
      # pack our arguments
-    $bofArgs = bof_pack($1, "ziiiiizzzib", $_appDomainArgs, $_amsi, $_etw, $_revertETW, $_mailSlot, $_entryPoint, $_mailSlotNameArgs, $_pipeNameArgs, $_assemblyWithArgs, $assemblyLength, $assemblyBytes);
+    $bofArgs = bof_pack($1, "ziiiiizzzb", $_appDomainArgs, $_amsi, $_etw, $_revertETW, $_mailSlot, $_entryPoint, $_mailSlotNameArgs, $_pipeNameArgs, $_assemblyWithArgs, $assemblyBytes);
 
     # announce what we're doing 
     btask($1, "Running inlineExecute-Assembly by (@anthemtotheego)");

--- a/src/inlineExecute-Assembly.c
+++ b/src/inlineExecute-Assembly.c
@@ -336,7 +336,7 @@ void go(char* args, int length) {//Executes .NET assembly in memory
 	BOOL revertETW = 0;
 	BOOL mailSlot = 0;
 	ULONG entryPoint = 1;
-	size_t assemblyByteLen = 0;
+	int assemblyByteLen = 0;
 	
 	//Extract data sent
 	appDomain = BeaconDataExtract(&parser, NULL);
@@ -348,8 +348,7 @@ void go(char* args, int length) {//Executes .NET assembly in memory
 	slotName = BeaconDataExtract(&parser, NULL);
 	pipeName = BeaconDataExtract(&parser, NULL);
 	assemblyArguments = BeaconDataExtract(&parser, NULL);
-	assemblyByteLen = BeaconDataInt(&parser);
-	char* assemblyBytes = BeaconDataExtract(&parser, NULL);
+	char* assemblyBytes = BeaconDataExtract(&parser, &assemblyByteLen);
 	
 	//Create slot and pipe names	
 	SIZE_T pipeNameLen = MSVCRT$strlen(pipeName);


### PR DESCRIPTION
BeaconDataExtract provides the size of the extracted data through the optional size parameter. Using that allows the parameter to be removed and also eliminates the possibility of a descrepancy where size != len(data).

This doesn't make much of a difference for Cobalt Strike users because the aggressor script handled the value automatically. For Metasploit users however, it removes the necessity to know the size in bytes of the .NET executable file. This makes it easier to use since the BOF arguments have to be explicitly packed.

See:
  https://hstechdocs.helpsystems.com/manuals/cobaltstrike/current/userguide/content/topics/beacon-object-files_main.htm#BeaconDataExtract

Metasploit examples (because I don't have Cobalt Strike)
**Before** Note the 10th parameter 4608 which is the size in bytes of HelloWorld1.exe.
```
meterpreter > execute_bof /home/smcintyre/Repositories/InlineExecute-Assembly/inlineExecuteAssembly/inlineExecute-Assemblyx64.o --format-string ziiiiizzzib "totesLegit" 0 0 0 0 1 "totesLegit" "totesLegit" "" 4608 file:/home/smcintyre/HelloWorld1.exe


Hello, World

[+] inlineExecute-Assembly Finished

meterpreter >
```

**After** Now there are only 10 parameters because the size doesn't need to be specified.
```
meterpreter > execute_bof /home/smcintyre/Repositories/InlineExecute-Assembly/src/inlineExecute-Assemblyx64.o --format-string ziiiiizzzb "totesLegit" 0 0 0 0 1 "totesLegit" "totesLegit" "" file:/home/smcintyre/HelloWorld1.exe


Hello, World

[+] inlineExecute-Assembly Finished

meterpreter > 
```